### PR TITLE
Include the Field Id

### DIFF
--- a/pipefy.py
+++ b/pipefy.py
@@ -909,7 +909,7 @@ class Pipefy(object):
 
         response_fields = response_fields or 'assignees { id name } created_at created_by { id name } due_date' \
             ' finished_at id labels { id name } parent_relations { name source_type } record_fields { array_value ' \
-            'date_value datetime_value filled_at float_value name required updated_at value } summary { title value } ' \
+            'field {id} date_value datetime_value filled_at float_value name required updated_at value } summary { title value } ' \
             'table { id } title updated_at url }'
         query = '{ table_record(id: %(id)s) { %(response_fields)s } }' % {
             'id': json.dumps(id),


### PR DESCRIPTION
When we need to update/insert new table record, is necessary to know the field id. Most of the cases the id is the name of the field in lower cases, but sometimes, the filed id is named like "o_qu" which is the first field when is created.
Without know, exactly the field id is not possible to create new records nor updates.